### PR TITLE
Fixed trimRGB to format fullstops correctly - #53

### DIFF
--- a/src/app/helper/colourHelper.js
+++ b/src/app/helper/colourHelper.js
@@ -201,8 +201,12 @@ helper = {
         arr.forEach((chr, idx) => {
             inc++;
             if (commaCount < 3) {
-                if(chr === ",") {
+                if (chr === ",") {
                     commaCount++;
+                    inc = 0;
+                }
+                if (chr === ".") {
+                    tmp = tmp.substring(0,idx);
                     inc = 0;
                 }
                 if (inc > 3 && chr !== ",") {

--- a/test/specs/helper/colourHelper.spec.js
+++ b/test/specs/helper/colourHelper.spec.js
@@ -144,10 +144,6 @@ describe("Tests for helper/colourHelper.js", () => {
 
             expect(ColourHelper.trimRgb("123 123 123")).to.equal("123,123,123");
 
-            // bug identified here
-            // This is a bug where 3 characters allows the fullstop and 2 characters doesn't
-            expect(ColourHelper.trimRgb("123.")).to.equal("123,.");
-
             expect(ColourHelper.trimRgb("rgb(123,123,123)")).to.equal("123,123,123");
 
             // bug identified here
@@ -158,7 +154,17 @@ describe("Tests for helper/colourHelper.js", () => {
 
             // bug identified here
             // shouldn't allow initial fullstop
-            // expect(ColourHelper.trimRgb(".")).to.equal("");
+            expect(ColourHelper.trimRgb(".")).to.equal("");
+
+            expect(ColourHelper.trimRgb("123.")).to.equal("123");
+
+            expect(ColourHelper.trimRgb("123,123.")).to.equal("123,123");
+
+            expect(ColourHelper.trimRgb("123,123,123.")).to.equal("123,123,123");
+
+            expect(ColourHelper.trimRgb("123,123,123,.")).to.equal("123,123,123,");
+
+            expect(ColourHelper.trimRgb("123,123,123,0.5")).to.equal("123,123,123,0.5");
 
             expect(ColourHelper.trimRgb("123,123,123,0.9,")).to.equal("123,123,123,0.9");
 


### PR DESCRIPTION
Resolves issues around fullstops.

Fullstops are only allowed in the 4th segment of the conversion, and only after a zero.