### PR TITLE
zeros shouldn't be allowed as first char in first 3 sections - #53

### DIFF
--- a/src/app/helper/colourHelper.js
+++ b/src/app/helper/colourHelper.js
@@ -205,6 +205,9 @@ helper = {
                     commaCount++;
                     inc = 0;
                 }
+                if (inc === 1 && chr === "0") {
+                    tmp = tmp.substring(0,idx);
+                }
                 if (inc > 3 && chr !== ",") {
                     tmp = tmp.substring(0,idx) + "," + tmp.substring(idx);
                     inc = 0;

--- a/test/specs/helper/colourHelper.spec.js
+++ b/test/specs/helper/colourHelper.spec.js
@@ -182,9 +182,13 @@ describe("Tests for helper/colourHelper.js", () => {
 
             expect(ColourHelper.trimRgb("255,255,256")).to.equal("255,255,25");
 
-            // bug identified here
-            // zeros shouldn't be allowed in first 3 sections
-            // expect(ColourHelper.trimRgb("255,255,0")).to.equal("255,255,0");
+            expect(ColourHelper.trimRgb("0")).to.equal("");
+
+            expect(ColourHelper.trimRgb("255,0")).to.equal("255,");
+
+            expect(ColourHelper.trimRgb("255,255,0")).to.equal("255,255,");
+            
+            expect(ColourHelper.trimRgb("255,255,255,0")).to.equal("255,255,255,0");
 
         });
 


### PR DESCRIPTION
Stops the first character in any of the first 3 sections from being a zero. Updated tests to reflect change.